### PR TITLE
DF-1288 Disable datetime formatting when there is no translations configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- DF-1288 Disable datetime types formatting when there is no translations configured
+
 ## [0.9.1] - 2018-01-25
 ### Added
 - DF-1275 Initial support for multi-column constraints

--- a/src/Components/Schema.php
+++ b/src/Components/Schema.php
@@ -1987,9 +1987,9 @@ MYSQL;
             case DbSimpleTypes::TYPE_TIMESTAMP_ON_CREATE:
             case DbSimpleTypes::TYPE_TIMESTAMP_ON_UPDATE:
                 return static::formatDateTime(
-                    static::getConfigDateTimeFormat($type),
-                    $value,
-                    static::getNativeDateTimeFormat($field_info)
+                    $this->getConfigDateTimeFormat($type),
+                    $this->getNativeDateTimeFormat($field_info),
+                    $value
                 );
         }
 
@@ -2064,42 +2064,42 @@ MYSQL;
     }
 
     /**
-     * @param      $out_format
-     * @param null $in_value
-     * @param null $in_format
+     * @param string $out_format
+     * @param string $in_format
+     * @param mixed $value
      *
      * @return null|string
      */
-    public static function formatDateTime($out_format, $in_value = null, $in_format = null)
+    public static function formatDateTime($out_format, $in_format, $value = null)
     {
-        //  If value is null, current date and time are returned
-        if (!empty($out_format)) {
-            $in_value = (is_string($in_value) || is_null($in_value)) ? $in_value : strval($in_value);
-            if (!empty($in_format)) {
-                if (false === $date = \DateTime::createFromFormat($in_format, $in_value)) {
-                    \Log::error("Failed to create datetime with '$in_value' as format '$in_format'");
+        if (!empty($out_format) && !empty($in_format)) {
+            $value = (is_string($value) || is_null($value)) ? $value : strval($value);
+            if (!empty($value)) {
+                if (false === $date = \DateTime::createFromFormat($in_format, $value)) {
+                    \Log::error("Failed to create datetime with '$value' as format '$in_format'");
                     try {
-                        $date = new \DateTime($in_value);
+                        $date = new \DateTime($value);
                     } catch (\Exception $e) {
-                        \Log::error("Failed to create datetime from '$in_value': " . $e->getMessage());
+                        \Log::error("Failed to create datetime from '$value': " . $e->getMessage());
 
-                        return $in_value;
+                        return $value;
                     }
                 }
             } else {
+                //  If value is null, current date and time are returned
                 try {
-                    $date = new \DateTime($in_value);
+                    $date = new \DateTime();
                 } catch (\Exception $e) {
-                    \Log::error("Failed to create datetime from '$in_value': " . $e->getMessage());
+                    \Log::error("Failed to create current datetime: " . $e->getMessage());
 
-                    return $in_value;
+                    return $value;
                 }
             }
 
             return $date->format($out_format);
         }
 
-        return $in_value;
+        return $value;
     }
 
     /**
@@ -2160,9 +2160,9 @@ MYSQL;
             case DbSimpleTypes::TYPE_TIMESTAMP_ON_CREATE:
             case DbSimpleTypes::TYPE_TIMESTAMP_ON_UPDATE:
                 $value = $this->formatDateTime(
-                    static::getNativeDateTimeFormat($field_info),
-                    $value,
-                    static::getConfigDateTimeFormat($field_info->type)
+                    $this->getNativeDateTimeFormat($field_info),
+                    $this->getConfigDateTimeFormat($field_info->type),
+                    $value
                 );
                 break;
 


### PR DESCRIPTION
This change disables the formatDateTime functionality when there is no configured "preferred date time formats" (see config/df.php). This requires the client to use an "acceptable" format (many databases support multiple). A more feature-rich fix would be to interrogate the database for the language/date_format setting and always translate accordingly.

Side-effects: If a client is currently sending date formats that are not accepted by the underlying database, they will now get an error, vs. previously the values were formatted based on our 'hard-coded' default for each db vendor.  As most databases accept multiple formats, this should rarely be the case.