### PR TITLE
Add getResourceIdentifier method to DbSchemaResource for PHP 8.3 comp…

### DIFF
--- a/src/Resources/DbSchemaResource.php
+++ b/src/Resources/DbSchemaResource.php
@@ -4,6 +4,7 @@ namespace DreamFactory\Core\Database\Resources;
 
 use DreamFactory\Core\Components\DataValidator;
 use DreamFactory\Core\Database\Components\TableDescriber;
+use DreamFactory\Core\Database\Components\DbSchemaExtras;
 use DreamFactory\Core\Database\Enums\DbFunctionUses;
 use DreamFactory\Core\Database\Enums\FunctionTypes;
 use DreamFactory\Core\Database\Schema\ColumnSchema;
@@ -28,7 +29,7 @@ use DreamFactory\Core\Resources\BaseRestResource;
 
 class DbSchemaResource extends BaseRestResource
 {
-    use DataValidator, TableDescriber;
+    use DataValidator, TableDescriber, DbSchemaExtras;
 
     //*************************************************************************
     //	Constants

--- a/src/Resources/DbSchemaResource.php
+++ b/src/Resources/DbSchemaResource.php
@@ -105,6 +105,14 @@ class DbSchemaResource extends BaseRestResource
     /**
      * {@inheritdoc}
      */
+    protected static function getResourceIdentifier()
+    {
+        return 'name';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function listResources($schema = null, $refresh = false)
     {
         $result = $this->parent->getTableNames($schema, $refresh);


### PR DESCRIPTION
…atibility

For whatever reason, when calling the /_schema endpoint, DF was freaking out over a missing resource identifier. This should resolve. 