### PR TITLE
test: add void return type to tearDown() for PHPUnit 9 compat

### DIFF
--- a/src/Testing/DbServiceConfigTestCase.php
+++ b/src/Testing/DbServiceConfigTestCase.php
@@ -38,7 +38,7 @@ class DbServiceConfigTestCase extends TestCase
         return $config;
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         foreach ($this->types as $type) {
             Service::whereName($type . '-db')->delete();


### PR DESCRIPTION
## Summary
- PHPUnit 9 flags `tearDown()` without an explicit `: void` return type as deprecated; the warning trips strict runs across consumers of this trait.

## Test plan
- [ ] CI passes on this branch