### PR TITLE
Laravel 13 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.idea
 composer.phar
 composer.lock
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -31,10 +31,13 @@
   "minimum-stability": "dev",
   "prefer-stable":     true,
   "require":     {
+    "php": "^8.3",
     "dreamfactory/df-core": "~1.0.4"
   },
   "require-dev": {
-    "phpunit/phpunit": "@stable"
+    "laravel/framework": "^13.7",
+    "phpunit/phpunit": "^11.5.3",
+    "orchestra/testbench": "^11.0"
   },
   "autoload":    {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -32,10 +32,13 @@
   "prefer-stable":     true,
   "require":     {
     "php": "^8.3",
+    "laravel/helpers": "^1.8",
     "dreamfactory/df-core": "~1.0.4"
   },
   "require-dev": {
     "laravel/framework": "^13.7",
+    "mockery/mockery": "^1.6",
+    "nunomaduro/collision": "^8.6",
     "phpunit/phpunit": "^11.5.3",
     "orchestra/testbench": "^11.0"
   },


### PR DESCRIPTION
## Summary

Laravel 13 compatibility upgrade for df-database. Composer-only dep matrix bump.

Part of the Laravel 11→13 upgrade campaign. Pilot: dreamfactorysoftware/df-core#162. df-database is the base for 9+ DB connector packages — public API surface is preserved (zero src/ changes).

## Changes

Two commits:
1. `Laravel 13 compatibility` — composer.json: `php → ^8.3`, `require-dev`: laravel/framework ^13.7, phpunit ^11.5.3, orchestra/testbench ^11.0; `.gitignore`: `.phpunit.result.cache`
2. `Address review: explicit laravel/helpers + align dev tooling` — added `laravel/helpers: ^1.8` to production require (df-database has 339+ `array_get` and 9 `array_except` call sites — now declared explicitly rather than relying on transitive resolution via df-core); aligned `mockery: ^1.6` and `nunomaduro/collision: ^8.6` in require-dev with df-system / df-user.

## Test plan

- [x] `composer validate --strict` — valid
- [x] `composer install` resolves L13.7.0 + phpunit 11.5.55 + testbench v11.1.0 cleanly with df-core path-repo
- [x] `php -l` clean over 30 PHP files
- [x] `./vendor/bin/phpunit` — `OK (13 tests, 26 assertions)` — security regression suite (`DbFunctionTemplateTest`) green under PHPUnit 11.5 + L13.7
- [x] Stage 2 host-app integration: ServiceProvider boot + class resolution clean under L13.7.0
- [x] Independent code-review-expert pass: Conditional Pass → resolved with the laravel/helpers add

## Notes

- Branch based on `origin/master` so `claude-virtual-rel-transactions` (active in-flight virtual relation transactions work) is preserved untouched.
- 9 downstream connector packages (df-sqldb, df-mysqldb, df-mongodb, etc.) see no source-level breaks — zero src/ changes here.