### PR TITLE
release: develop → master cut for Laravel 13 / PHP 8.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.idea
 composer.phar
 composer.lock
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -31,10 +31,13 @@
   "minimum-stability": "dev",
   "prefer-stable":     true,
   "require":     {
+    "php": "^8.3",
     "dreamfactory/df-core": "~1.0.4"
   },
   "require-dev": {
-    "phpunit/phpunit": "@stable"
+    "laravel/framework": "^13.7",
+    "phpunit/phpunit": "^11.5.3",
+    "orchestra/testbench": "^11.0"
   },
   "autoload":    {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -32,10 +32,13 @@
   "prefer-stable":     true,
   "require":     {
     "php": "^8.3",
+    "laravel/helpers": "^1.8",
     "dreamfactory/df-core": "~1.0.4"
   },
   "require-dev": {
     "laravel/framework": "^13.7",
+    "mockery/mockery": "^1.6",
+    "nunomaduro/collision": "^8.6",
     "phpunit/phpunit": "^11.5.3",
     "orchestra/testbench": "^11.0"
   },

--- a/src/Components/Schema.php
+++ b/src/Components/Schema.php
@@ -1105,10 +1105,39 @@ MYSQL;
 
         // string additional SQL fragment that will be appended to the generated SQL
         if (!empty($addOn = array_get($table, 'options'))) {
+            self::assertSafeTableOptions($addOn);
             $sql .= ' ' . $addOn;
         }
 
         return $this->connection->statement($sql);
+    }
+
+    /**
+     * Validate the caller-supplied `options` string before appending it to
+     * a CREATE TABLE statement. Allows the typical ENGINE/CHARSET fragments
+     * (alphanumeric tokens, whitespace, '=', ',', and quoted value literals)
+     * but rejects shell/SQL metacharacters that would enable stacked
+     * statements or injection.
+     *
+     * @throws \DreamFactory\Core\Exceptions\BadRequestException
+     */
+    public static function assertSafeTableOptions(string $options): void
+    {
+        // Reject anything containing a semicolon (stacked statements),
+        // backslash, comment markers, or backtick / double-quote that
+        // could break out of the appended fragment.
+        if (preg_match('/[;\\\\`]|--|\/\*|\*\//', $options) === 1) {
+            throw new \DreamFactory\Core\Exceptions\BadRequestException(
+                'Table options contain forbidden characters.'
+            );
+        }
+        // Allowlist: word chars, whitespace, '=', ',', '.', '-', '+', and
+        // single-quoted literal values. Anything outside this set fails.
+        if (preg_match('/^[A-Za-z0-9_\s=,\.\-\+\'"\(\)\/]*$/u', $options) !== 1) {
+            throw new \DreamFactory\Core\Exceptions\BadRequestException(
+                'Table options string contains characters not allowed in a CREATE TABLE options append.'
+            );
+        }
     }
 
     /**
@@ -1150,7 +1179,27 @@ MYSQL;
      */
     public function dropTable($table)
     {
-        return $this->connection->statement("DROP TABLE $table");
+        // Defense-in-depth: callers in the schema layer typically pass a
+        // pre-quoted identifier (TableSchema->quotedName), but a direct
+        // caller could pass a raw table name. quoteTableName() is idempotent
+        // when the input already starts with the quote character on each
+        // driver (MySQL backtick, sqlsrv brackets, pgsql/sqlite double-quote).
+        $quoted = (str_starts_with(ltrim($table), $this->getQuoteChar()) ?? false)
+            ? $table
+            : $this->quoteTableName($table);
+        return $this->connection->statement("DROP TABLE {$quoted}");
+    }
+
+    /**
+     * Driver-aware leading quote character. Subclasses override
+     * LEFT_QUOTE_CHARACTER; default is the SQL standard double-quote.
+     */
+    protected function getQuoteChar(): string
+    {
+        $cls = static::class;
+        return defined("{$cls}::LEFT_QUOTE_CHARACTER")
+            ? constant("{$cls}::LEFT_QUOTE_CHARACTER")
+            : '"';
     }
 
     /**
@@ -1162,14 +1211,23 @@ MYSQL;
     public function dropColumns($table, $columns)
     {
         $commands = [];
+        $quoteChar = $this->getQuoteChar();
         foreach ((array)$columns as $column) {
             if (!empty($column)) {
-                $commands[] = "DROP COLUMN " . $column;
+                // Quote each column identifier — callers historically passed
+                // raw user-supplied column names. Skip if already quoted.
+                $quotedCol = str_starts_with(ltrim($column), $quoteChar)
+                    ? $column
+                    : $this->quoteColumnName($column);
+                $commands[] = "DROP COLUMN " . $quotedCol;
             }
         }
 
         if (!empty($commands)) {
-            return $this->connection->statement("ALTER TABLE $table " . implode(',', $commands));
+            $quotedTable = str_starts_with(ltrim($table), $quoteChar)
+                ? $table
+                : $this->quoteTableName($table);
+            return $this->connection->statement("ALTER TABLE {$quotedTable} " . implode(',', $commands));
         }
 
         return false;

--- a/src/Resources/BaseDbTableResource.php
+++ b/src/Resources/BaseDbTableResource.php
@@ -3003,7 +3003,7 @@ abstract class BaseDbTableResource extends BaseDbResource
                 if (count($checkIds) > 1) {
                     $filter = $refPkFieldAlias . ' IN (' . implode(',', array_map([self::class, 'formatPkFilterValue'], $checkIds)) . ')';
                 } else {
-                    $filter = $refPkFieldAlias . ' = ' . $checkIds[0];
+                    $filter = $refPkFieldAlias . ' = ' . self::formatPkFilterValue($checkIds[0]);
                 }
                 $temp = [ApiOptions::FILTER => $filter];
                 $matchIds = $this->retrieveVirtualRecords($refService, '_table/' . $refTable, $temp);

--- a/src/Resources/BaseDbTableResource.php
+++ b/src/Resources/BaseDbTableResource.php
@@ -43,6 +43,42 @@ abstract class BaseDbTableResource extends BaseDbResource
     //*************************************************************************
 
     /**
+     * Format a primary-key value for safe interpolation into an
+     * ApiOptions::FILTER expression.
+     *
+     * Numeric values are returned unquoted. String values must match a strict
+     * allowlist (alphanumeric, dash, underscore — covers integers, UUIDs,
+     * slugs); any other character throws BadRequestException. The strict
+     * allowlist forecloses the SQL-syntax bypass paths the relationship code
+     * has historically been vulnerable to (single quote, comment, paren,
+     * stacked statement) without requiring deep changes to the downstream
+     * filter parser.
+     *
+     * @param  mixed $value  The PK value to embed.
+     * @return string        Interpolation-safe representation: numeric raw,
+     *                       string single-quoted.
+     * @throws BadRequestException  When $value is non-scalar or contains
+     *                              characters outside the allowlist.
+     */
+    public static function formatPkFilterValue($value): string
+    {
+        if (is_int($value) || is_float($value)) {
+            return (string) $value;
+        }
+        if (!is_string($value)) {
+            throw new BadRequestException(
+                'Relationship filter values must be scalar primary-key values.'
+            );
+        }
+        if (preg_match('/^[A-Za-z0-9_-]+$/', $value) !== 1) {
+            throw new BadRequestException(
+                'Relationship filter primary-key value contains forbidden characters.'
+            );
+        }
+        return "'" . $value . "'";
+    }
+
+    /**
      * Resource tag for dealing with table schema
      */
     const RESOURCE_NAME = '_table';
@@ -2096,7 +2132,7 @@ abstract class BaseDbTableResource extends BaseDbResource
 
                 // Get records
                 $refFieldName = $refField->getName(true);
-                $extras[ApiOptions::FILTER] = "($refFieldName IN (" . implode(',', $values) . '))';
+                $extras[ApiOptions::FILTER] = "($refFieldName IN (" . implode(',', array_map([self::class, 'formatPkFilterValue'], $values)) . '))';
                 $fields = array_get($extras, 'fields');
                 if ($removeLater = static::addToFields($fields, $refFieldName)) {
                     $extras['fields'] = $fields;
@@ -2139,7 +2175,7 @@ abstract class BaseDbTableResource extends BaseDbResource
 
                 // Get records
                 $refFieldName = $refField->getName(true);
-                $extras[ApiOptions::FILTER] = "($refFieldName IN (" . implode(',', $values) . '))';
+                $extras[ApiOptions::FILTER] = "($refFieldName IN (" . implode(',', array_map([self::class, 'formatPkFilterValue'], $values)) . '))';
                 $fields = array_get($extras, 'fields');
                 if ($removeLater = static::addToFields($fields, $refFieldName)) {
                     $extras['fields'] = $fields;
@@ -2182,7 +2218,7 @@ abstract class BaseDbTableResource extends BaseDbResource
 
                 // Get records
                 $refFieldName = $refField->getName(true);
-                $extras[ApiOptions::FILTER] = "($refFieldName IN (" . implode(',', $values) . '))';
+                $extras[ApiOptions::FILTER] = "($refFieldName IN (" . implode(',', array_map([self::class, 'formatPkFilterValue'], $values)) . '))';
                 $fields = array_get($extras, 'fields');
                 if ($removeLater = static::addToFields($fields, $refFieldName)) {
                     $extras['fields'] = $fields;
@@ -2235,7 +2271,7 @@ abstract class BaseDbTableResource extends BaseDbResource
                 // Get records
                 $junctionFieldName = $junctionField->getName(true);
                 $junctionRefFieldName = $junctionRefField->getName(true);
-                $filter = "($junctionFieldName IN (" . implode(',', $values) . '))';
+                $filter = "($junctionFieldName IN (" . implode(',', array_map([self::class, 'formatPkFilterValue'], $values)) . '))';
                 $filter .= static::padOperator(DbLogicalOperators::AND_STR);
                 $filter .= "($junctionRefFieldName " . DbComparisonOperators::IS_NOT_NULL . ')';
                 $temp = [
@@ -2267,7 +2303,7 @@ abstract class BaseDbTableResource extends BaseDbResource
                         $refFieldName = $refField->getName(true);
 
                         // Get records
-                        $filter = $refFieldName . ' IN (' . implode(',', $relatedIds) . ')';
+                        $filter = $refFieldName . ' IN (' . implode(',', array_map([self::class, 'formatPkFilterValue'], $relatedIds)) . ')';
                         $extras[ApiOptions::FILTER] = $filter;
                         $fields = array_get($extras, 'fields');
                         if ($removeLater = static::addToFields($fields, $refFieldName)) {
@@ -2361,7 +2397,7 @@ abstract class BaseDbTableResource extends BaseDbResource
             } else {
                 // update or insert a parent
                 // Get records
-                $filterVal = ('string' === gettype($id)) ? "'$id'" : $id;
+                $filterVal = self::formatPkFilterValue($id);
                 $temp = [ApiOptions::FILTER => "$pkFieldAlias = $filterVal"];
                 $matchIds = $this->retrieveVirtualRecords($refService, '_table/' . $refTable, $temp);
 
@@ -2457,7 +2493,7 @@ abstract class BaseDbTableResource extends BaseDbResource
             if (empty($child_record)) {
                 // Get record
                 $temp = [
-                    ApiOptions::FILTER => $refFieldAlias . ' = ' . $parent_id,
+                    ApiOptions::FILTER => $refFieldAlias . ' = ' . self::formatPkFilterValue($parent_id),
                     ApiOptions::FIELDS => $pkFieldAlias,
                 ];
                 $matchIds = $this->retrieveVirtualRecords($refService, '_table/' . $refTable, $temp);
@@ -2509,7 +2545,7 @@ abstract class BaseDbTableResource extends BaseDbResource
                         if ($pkAutoSet) {
                             $this->updateForeignRecords($refService, $refSchema, $pkField, [$child_record]);
                         } else {
-                            $temp = [ApiOptions::FILTER => $pkFieldAlias . ' = ' . $id];
+                            $temp = [ApiOptions::FILTER => $pkFieldAlias . ' = ' . self::formatPkFilterValue($id)];
                             $matchIds = $this->retrieveVirtualRecords($refService, '_table/' . $refTable, $temp);
                             if ($found = static::findRecordByNameValue($matchIds, $pkFieldAlias, $id)) {
                                 $this->updateForeignRecords($refService, $refSchema, $pkField, [$child_record]);
@@ -2637,10 +2673,11 @@ abstract class BaseDbTableResource extends BaseDbResource
             if (!empty($upsertMany)) {
                 // Get records
                 $checkIds = array_keys($upsertMany);
-                if (count($checkIds) > 1) {
-                    $filter = $pkFieldAlias . ' IN (' . implode(',', $checkIds) . ')';
+                $safeCheckIds = array_map(static fn ($v) => self::formatPkFilterValue($v), $checkIds);
+                if (count($safeCheckIds) > 1) {
+                    $filter = $pkFieldAlias . ' IN (' . implode(',', $safeCheckIds) . ')';
                 } else {
-                    $filter = $pkFieldAlias . ' = ' . $checkIds[0];
+                    $filter = $pkFieldAlias . ' = ' . $safeCheckIds[0];
                 }
                 $temp = [ApiOptions::FILTER => $filter];
                 $matchIds = $this->retrieveVirtualRecords($refService, '_table/' . $refTable, $temp);
@@ -2790,7 +2827,7 @@ abstract class BaseDbTableResource extends BaseDbResource
         $context = null
     ) {
         if (!empty($addCondition) && is_array($addCondition)) {
-            $filter = '(' . $linkerField->getName(true) . ' IN (' . implode(',', $linkerIds) . '))';
+            $filter = '(' . $linkerField->getName(true) . ' IN (' . implode(',', array_map([self::class, 'formatPkFilterValue'], $linkerIds)) . '))';
             foreach ($addCondition as $key => $value) {
                 $column = $schema->getColumn($key);
                 $filter .= ' AND (' . $column->getName(true) . ' = ' . $value . ')';
@@ -2960,7 +2997,7 @@ abstract class BaseDbTableResource extends BaseDbResource
                 // Get records
                 $checkIds = array_keys($upsertMany);
                 if (count($checkIds) > 1) {
-                    $filter = $refPkFieldAlias . ' IN (' . implode(',', $checkIds) . ')';
+                    $filter = $refPkFieldAlias . ' IN (' . implode(',', array_map([self::class, 'formatPkFilterValue'], $checkIds)) . ')';
                 } else {
                     $filter = $refPkFieldAlias . ' = ' . $checkIds[0];
                 }

--- a/src/Resources/BaseDbTableResource.php
+++ b/src/Resources/BaseDbTableResource.php
@@ -70,7 +70,11 @@ abstract class BaseDbTableResource extends BaseDbResource
                 'Relationship filter values must be scalar primary-key values.'
             );
         }
-        if (preg_match('/^[A-Za-z0-9_-]+$/', $value) !== 1) {
+        // Allowlist: alphanumerics + a small set of identifier-ish characters
+        // (dot, at, plus, hyphen, underscore) to support email-style PKs,
+        // UUIDs, and slugs. Keeps quotes / parens / whitespace / SQL keywords
+        // out — those are the actual injection enablers.
+        if (preg_match('/^[A-Za-z0-9._@+\-]+$/', $value) !== 1) {
             throw new BadRequestException(
                 'Relationship filter primary-key value contains forbidden characters.'
             );

--- a/src/Resources/DbSchemaResource.php
+++ b/src/Resources/DbSchemaResource.php
@@ -1460,14 +1460,27 @@ class DbSchemaResource extends BaseRestResource
         }
 
         try {
-            $tableSchema = $this->parent->getTableSchema($table);
+            // Refresh so a stale schema cache (e.g. relation added in another request)
+            // does not cause the relation lookup below to silently miss.
+            $tableSchema = $this->parent->getTableSchema($table, true);
             if ($resource = $tableSchema->getRelation($relationship)) {
                 if ($resource->isVirtual) {
                     $this->removeSchemaVirtualRelationships($table, [$resource->toArray()]);
                 } else {
-                    $this->parent->getSchema()->dropRelationship($tableSchema->quotedName, $resource);
+                    // Native FK relationships derive from the database schema itself.
+                    // Schema::dropRelationship is a stub returning false in the base
+                    // class — surface that honestly instead of returning 200/success.
+                    $dropped = $this->parent->getSchema()->dropRelationship($tableSchema->quotedName, $resource);
+                    if ($dropped === false) {
+                        throw new BadRequestException(
+                            "Relationship '$relationship' is derived from a native foreign key on table '$table' and cannot be removed via this endpoint. " .
+                            "Drop the underlying foreign key constraint via the database directly."
+                        );
+                    }
                 }
                 $this->removeSchemaExtrasForRelated($table, $relationship);
+            } else {
+                throw new NotFoundException("Relationship '$relationship' does not exist on table '$table'.");
             }
         } catch (\Exception $ex) {
             error_log($ex->getMessage());
@@ -2264,6 +2277,30 @@ class DbSchemaResource extends BaseRestResource
                     $relation = array_except($relation, $noDiff);
                     if (!empty(array_diff_assoc($relation, array_except($oldArray, $noDiff)))) {
                         $relation['table'] = $table_schema->name;
+
+                        // setSchemaVirtualRelationships updateOrCreate keys on the full
+                        // (type, field, ref_*, junction_*) tuple. If any of those columns
+                        // changed, the call would INSERT a duplicate row instead of
+                        // updating the existing one. Queue the old row for deletion so
+                        // we end up with exactly one row representing this relation.
+                        if ($oldRelation->isVirtual) {
+                            $tupleCols = [
+                                'type', 'field', 'ref_service_id', 'ref_table', 'ref_field',
+                                'junction_service_id', 'junction_table', 'junction_field', 'junction_ref_field',
+                            ];
+                            $tupleChanged = false;
+                            foreach ($tupleCols as $col) {
+                                if ((array_get($oldArray, $col) ?: null) != (array_get($relation, $col) ?: null)) {
+                                    $tupleChanged = true;
+                                    break;
+                                }
+                            }
+                            if ($tupleChanged) {
+                                $oldRow = $oldArray;
+                                $oldRow['table'] = $table_schema->name;
+                                $dropVirtuals[$table_schema->name][] = $oldRow;
+                            }
+                        }
                         $virtuals[] = $relation;
                     }
                 }
@@ -2301,10 +2338,10 @@ class DbSchemaResource extends BaseRestResource
             }
         }
 
-        if ($allow_delete && isset($oldSchema)) {
+        if ($allow_delete) {
             // check for relations to drop
-            /** @type RelationSchema $oldField */
-            foreach ($oldSchema->getRelations() as $oldRelation) {
+            /** @type RelationSchema $oldRelation */
+            foreach ($table_schema->getRelations() as $oldRelation) {
                 $found = false;
                 foreach ($related as $relation) {
                     $relation = array_change_key_case($relation, CASE_LOWER);
@@ -2428,6 +2465,14 @@ class DbSchemaResource extends BaseRestResource
      */
     protected function cleanClientRelation(array &$relation)
     {
+        // Admin UI sends camelCase keys (isVirtual, refServiceId, refField, ...);
+        // backend logic looks them up as snake_case. Convert before the lowercase pass.
+        $converted = [];
+        foreach ($relation as $key => $value) {
+            $converted[Str::snake($key)] = $value;
+        }
+        $relation = $converted;
+
         $relation = array_change_key_case($relation, CASE_LOWER);
         // make sure we have boolean values, not integers or strings
         $booleanFieldNames = [
@@ -2457,6 +2502,51 @@ class DbSchemaResource extends BaseRestResource
                         throw new \Exception("Invalid schema detected - invalid or missing type element.");
                         break;
                 }
+            }
+            // Validate the per-type tuple is complete BEFORE the row is written.
+            // db_virtual_relationship doesn't store the relationship name — it's
+            // recomputed via RelationSchema::buildName on every schema describe.
+            // An incomplete tuple (e.g. many_many without junction_table) would
+            // cause every subsequent describe to throw a 500 until the row is
+            // manually deleted from the DB.
+            if (empty(array_get($relation, 'ref_table'))) {
+                throw new BadRequestException("Invalid relationship: 'ref_table' is required.");
+            }
+            switch ($relation['type']) {
+                case RelationSchema::BELONGS_TO:
+                    if (empty(array_get($relation, 'field'))) {
+                        throw new BadRequestException("Invalid belongs_to relationship: 'field' is required.");
+                    }
+                    break;
+                case RelationSchema::HAS_ONE:
+                case RelationSchema::HAS_MANY:
+                    if (empty(array_get($relation, 'ref_field'))) {
+                        throw new BadRequestException("Invalid {$relation['type']} relationship: 'ref_field' is required.");
+                    }
+                    break;
+                case RelationSchema::MANY_MANY:
+                    if (empty(array_get($relation, 'junction_table'))) {
+                        throw new BadRequestException("Invalid many_many relationship: 'junction_table' is required.");
+                    }
+                    if (empty(array_get($relation, 'junction_field'))) {
+                        throw new BadRequestException("Invalid many_many relationship: 'junction_field' is required.");
+                    }
+                    if (empty(array_get($relation, 'junction_ref_field'))) {
+                        throw new BadRequestException("Invalid many_many relationship: 'junction_ref_field' is required.");
+                    }
+                    break;
+            }
+            // Non-many_many relations have no use for junction_* values. If a payload
+            // arrives with stale junction fields (e.g. user toggled type away from
+            // many_many in the UI without fully clearing the form), null them out so
+            // we don't persist an incoherent row. Otherwise the next schema describe
+            // returns junction_service_id with a null junction_table, which the admin
+            // UI then uses to construct the URL `/_schema/null`.
+            if ($relation['type'] !== RelationSchema::MANY_MANY) {
+                $relation['junction_service_id'] = null;
+                $relation['junction_table']      = null;
+                $relation['junction_field']      = null;
+                $relation['junction_ref_field']  = null;
             }
         } else {
             if (empty(array_get($relation, 'name'))) {

--- a/src/Services/BaseDbService.php
+++ b/src/Services/BaseDbService.php
@@ -266,6 +266,21 @@ abstract class BaseDbService extends BaseRestService implements DbExtrasInterfac
      */
     public function getTableNames($schema = null, $refresh = false)
     {
+        class_exists(TableSchema::class);
+        class_exists(ColumnSchema::class);
+        class_exists(RelationSchema::class);
+
+        $tables = $this->getFromCache('tables');
+        if (!$refresh && is_array($tables)) {
+            foreach ($tables as $table) {
+                if (!$table instanceof TableSchema) {
+                    $this->removeFromCache('tables');
+                    $tables = null;
+                    break;
+                }
+            }
+        }
+
         if ($refresh || (is_null($tables = $this->getFromCache('tables')))) {
             $tables = [];
             $defaultSchema = $this->getNamingSchema();
@@ -327,6 +342,19 @@ abstract class BaseDbService extends BaseRestService implements DbExtrasInterfac
     {
         $result = null;
         $cacheKey = 'table:' . strtolower($name);
+
+        class_exists(TableSchema::class);
+        class_exists(ColumnSchema::class);
+        class_exists(RelationSchema::class);
+
+        if (!$refresh && ($cached = $this->getFromCache($cacheKey)) !== null) {
+            if ($cached instanceof TableSchema) {
+                return $cached;
+            }
+
+            $this->removeFromCache($cacheKey);
+        }
+
         if ($refresh || (is_null($result = $this->getFromCache($cacheKey)))) {
             $schema = $this->getSchema();
             if ($tableSchema = array_get($this->getTableNames(), strtolower($name))) {

--- a/tests/Security/RelationshipFilterPkValidationTest.php
+++ b/tests/Security/RelationshipFilterPkValidationTest.php
@@ -26,6 +26,16 @@ use PHPUnit\Framework\TestCase;
  */
 class RelationshipFilterPkValidationTest extends TestCase
 {
+    private string $sourcePath;
+    private string $contents;
+
+    protected function setUp(): void
+    {
+        $this->sourcePath = __DIR__ . '/../../src/Resources/BaseDbTableResource.php';
+        $this->assertFileExists($this->sourcePath);
+        $this->contents = file_get_contents($this->sourcePath);
+    }
+
     /**
      * @dataProvider validPkProvider
      */
@@ -74,5 +84,19 @@ class RelationshipFilterPkValidationTest extends TestCase
             'array'                  => [['evil']],
             'object'                 => [(object) ['x' => 1]],
         ];
+    }
+
+    public function testSingleUpsertIdPathAlsoUsesFormatter(): void
+    {
+        $start = strpos($this->contents, 'if (!empty($upsertMany))');
+        $this->assertNotFalse($start, 'upsertMany branch must exist');
+        $end = strpos($this->contents, "\n            if (!empty($insertMany))", $start);
+        $body = substr($this->contents, $start, $end === false ? null : ($end - $start));
+
+        $this->assertStringContainsString(
+            'self::formatPkFilterValue($checkIds[0])',
+            $body,
+            'Single-ID upsert filter path must route values through formatPkFilterValue()'
+        );
     }
 }

--- a/tests/Security/RelationshipFilterPkValidationTest.php
+++ b/tests/Security/RelationshipFilterPkValidationTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace DreamFactory\Core\Database\Tests\Security;
+
+use DreamFactory\Core\Database\Resources\BaseDbTableResource;
+use DreamFactory\Core\Exceptions\BadRequestException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Security: relationship-handling code in BaseDbTableResource interpolates
+ * primary-key values directly into ApiOptions::FILTER strings. Until those
+ * filters are parameterized end-to-end, the package must validate PK values
+ * before interpolation.
+ *
+ * The April 2026 audit (df-database F-02) found 6 inconsistent sites:
+ *
+ *     "$pkFieldAlias = $filterVal"               // line ~2365
+ *     $refFieldAlias . ' = ' . $parent_id        // line ~2460
+ *     $pkFieldAlias . ' = ' . $id                // line ~2512
+ *     $pkFieldAlias . ' IN (' . implode(',', $checkIds) . ')'   // line ~2641
+ *
+ * Some wrap strings in single quotes, others don't, none escape interior
+ * single quotes. After the fix, BaseDbTableResource exposes a static helper
+ * `formatPkFilterValue()` that validates+quotes a PK value safely, and the
+ * 6 call sites delegate to it.
+ */
+class RelationshipFilterPkValidationTest extends TestCase
+{
+    /**
+     * @dataProvider validPkProvider
+     */
+    public function testFormatPkAcceptsLegitimateIds($input, string $expected): void
+    {
+        $this->assertSame(
+            $expected,
+            BaseDbTableResource::formatPkFilterValue($input)
+        );
+    }
+
+    public static function validPkProvider(): array
+    {
+        return [
+            'positive int'   => [42, '42'],
+            'zero'           => [0, '0'],
+            'negative int'   => [-7, '-7'],
+            'float'          => [3.14, '3.14'],
+            'numeric string' => ['1234', "'1234'"],
+            'uuid-like'      => ['550e8400-e29b-41d4-a716-446655440000', "'550e8400-e29b-41d4-a716-446655440000'"],
+            'slug'           => ['user_42', "'user_42'"],
+            'alphanumeric'   => ['abc123', "'abc123'"],
+        ];
+    }
+
+    /**
+     * @dataProvider injectionPkProvider
+     */
+    public function testFormatPkRejectsInjectionPayloads($input): void
+    {
+        $this->expectException(BadRequestException::class);
+        BaseDbTableResource::formatPkFilterValue($input);
+    }
+
+    public static function injectionPkProvider(): array
+    {
+        return [
+            'single quote'           => ["1' OR '1'='1"],
+            'closing paren OR'       => ["1) OR (1=1"],
+            'comment terminator'     => ["1 -- "],
+            'stacked statement'      => ["1; DROP TABLE users"],
+            'union select'           => ["1 UNION SELECT password FROM user"],
+            'whitespace AND'         => ['1 AND 1=1'],
+            'newline'                => ["1\n2"],
+            'null byte'              => ["1\x00"],
+            'array'                  => [['evil']],
+            'object'                 => [(object) ['x' => 1]],
+        ];
+    }
+}

--- a/tests/Security/SchemaIdentifierQuotingTest.php
+++ b/tests/Security/SchemaIdentifierQuotingTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace DreamFactory\Core\Database\Tests\Security;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Security: Schema DDL helpers must quote identifiers and reject the unsafe
+ * `options` append that lets caller-supplied SQL ride along with CREATE TABLE.
+ *
+ * The April 2026 audit (df-database F-03 + F-04) flagged three sites in
+ * Components/Schema.php that interpolate caller input into raw DDL without
+ * quoting:
+ *
+ *   - createTable():  $sql .= ' ' . $addOn      // user-supplied 'options' field
+ *   - dropTable():    "DROP TABLE $table"        // unquoted identifier
+ *   - dropColumns():  "DROP COLUMN " . $column   // unquoted identifier
+ *
+ * After the fix:
+ *   - dropTable() and dropColumns() route identifiers through quoteTableName()
+ *     and quoteColumnName().
+ *   - createTable() validates the 'options' string against an allowlist
+ *     (alphanumeric, whitespace, equals, comma, single quotes for value
+ *     literals) — anything else throws BadRequestException. The legitimate
+ *     use is appending `ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`-style fragments;
+ *     stacked-statement payloads now fail validation.
+ */
+class SchemaIdentifierQuotingTest extends TestCase
+{
+    private string $sourcePath;
+    private string $contents;
+
+    protected function setUp(): void
+    {
+        $this->sourcePath = __DIR__ . '/../../src/Components/Schema.php';
+        $this->assertFileExists($this->sourcePath);
+        $this->contents = file_get_contents($this->sourcePath);
+    }
+
+    public function testDropTableQuotesIdentifier(): void
+    {
+        // The vulnerable pattern was: "DROP TABLE $table"
+        $this->assertDoesNotMatchRegularExpression(
+            '/"DROP TABLE \$table"/',
+            $this->contents,
+            'dropTable() must not interpolate the raw table identifier'
+        );
+        // Fix uses quoteTableName().
+        $this->assertMatchesRegularExpression(
+            '/quoteTableName\s*\(\s*\$table\s*\).*DROP\s+TABLE/s',
+            $this->contents,
+            'dropTable() must route identifiers through quoteTableName()'
+        );
+    }
+
+    public function testDropColumnsQuotesIdentifiers(): void
+    {
+        $this->assertDoesNotMatchRegularExpression(
+            '/"DROP COLUMN " \. \$column/',
+            $this->contents,
+            'dropColumns() must not interpolate raw column identifiers'
+        );
+        $this->assertMatchesRegularExpression(
+            '/DROP\s+COLUMN.*quoteColumnName\s*\(/s',
+            $this->contents,
+            'dropColumns() must quote each column identifier'
+        );
+    }
+
+    public function testCreateTableValidatesOptionsAppend(): void
+    {
+        // The fix must validate the 'options' string before append.
+        // We accept either a regex match against an allowlist or a call
+        // to a helper named like assertSafeTableOptions / validate*.
+        $hasGuard = preg_match(
+            '/preg_match\s*\([^)]+,\s*\$addOn\b/',
+            $this->contents
+        ) === 1
+        || preg_match(
+            '/(self|static)::assertSafeTableOptions\s*\(/',
+            $this->contents
+        ) === 1;
+
+        $this->assertTrue(
+            $hasGuard,
+            "createTable() must validate the 'options' string before appending. "
+            . 'Without this, a stacked-statement payload like "; DROP DATABASE x;" '
+            . 'rides along with the legitimate ENGINE/CHARSET fragment.'
+        );
+    }
+}


### PR DESCRIPTION
## Release prep: cut develop into master/main

Releases this package's `develop` line for the upcoming **DreamFactory
Laravel 13 + PHP 8.5** release.

### Verification

The develop HEAD on this branch is the SHA locked into the L13/PHP 8.5
test bundle that the team has been smoking. **Full end-to-end smoke
passed 2026-05-26**: PHP 8.5.5, Laravel 13.11.2, `df:setup` seeders,
admin login → JWT, service-type registration (81 types), Postgres
schema introspection + CRUD, OpenAPI generation.

### Coordinated release PRs

This is one of ~26 coordinated `develop → master/main` PRs opened
together as the release cut. Suggested merge order:

1. **Foundation**: df-core → df-system → df-user → df-database
2. **Connectors**: df-sqldb, df-sqlsrv, df-mongodb, df-oracledb, df-snowflake, df-soap, df-salesforce, df-script
3. **Auth**: df-oauth → df-adldap, df-azure-ad, df-oidc, df-saml
4. **Services**: df-email, df-file, df-cache, df-limits, df-logger, df-scheduler
5. **AI tier**: df-ai → df-ai-chat → df-mcp-server
6. **Admin UI**: df-admin-interface
7. **Host app**: dreamfactory/dreamfactory (released last)

### Customer upgrade path

In-place on Docker / managed Linux packages; blue-green strongly
recommended on Windows + custom-PHP-extension installs. Pre-flight
checklist in the release notes.
